### PR TITLE
Workfiles tool: Select latest workfile after model refresh

### DIFF
--- a/client/ayon_core/tools/workfiles/widgets/files_widget_workarea.py
+++ b/client/ayon_core/tools/workfiles/widgets/files_widget_workarea.py
@@ -20,6 +20,8 @@ class WorkAreaFilesModel(QtGui.QStandardItemModel):
         controller (AbstractWorkfilesFrontend): The control object.
     """
 
+    refreshed = QtCore.Signal()
+
     def __init__(self, controller):
         super(WorkAreaFilesModel, self).__init__()
 
@@ -163,6 +165,12 @@ class WorkAreaFilesModel(QtGui.QStandardItemModel):
             self._fill_items()
 
     def _fill_items(self):
+        try:
+            self._fill_items_impl()
+        finally:
+            self.refreshed.emit()
+
+    def _fill_items_impl(self):
         folder_id = self._selected_folder_id
         task_id = self._selected_task_id
         if not folder_id or not task_id:
@@ -285,6 +293,7 @@ class WorkAreaFilesWidget(QtWidgets.QWidget):
         selection_model.selectionChanged.connect(self._on_selection_change)
         view.double_clicked.connect(self._on_mouse_double_click)
         view.customContextMenuRequested.connect(self._on_context_menu)
+        model.refreshed.connect(self._on_model_refresh)
 
         controller.register_event_callback(
             "expected_selection_changed",
@@ -298,6 +307,7 @@ class WorkAreaFilesWidget(QtWidgets.QWidget):
         self._controller = controller
 
         self._published_mode = False
+        self._change_selection_on_refresh = True
 
     def set_published_mode(self, published_mode):
         """Set the published mode.
@@ -379,7 +389,9 @@ class WorkAreaFilesWidget(QtWidgets.QWidget):
         if not workfile_info["current"]:
             return
 
+        self._change_selection_on_refresh = False
         self._model.refresh()
+        self._change_selection_on_refresh = True
 
         workfile_name = workfile_info["name"]
         if (
@@ -393,4 +405,25 @@ class WorkAreaFilesWidget(QtWidgets.QWidget):
 
         self._controller.expected_workfile_selected(
             event["folder"]["id"], event["task"]["name"], workfile_name
+        )
+
+    def _on_model_refresh(self):
+        if (
+            not self._change_selection_on_refresh
+            or self._proxy_model.rowCount() < 1
+        ):
+            return
+
+        first_index = self._proxy_model.index(0, 0)
+        last_index = self._proxy_model.index(
+            0, self._proxy_model.columnCount() - 1
+        )
+        selection = QtCore.QItemSelection(first_index, last_index)
+        seleciton_model = self._view.selectionModel()
+        seleciton_model.select(
+            selection,
+            (
+                QtCore.QItemSelectionModel.ClearAndSelect
+                | QtCore.QItemSelectionModel.Current
+            )
         )


### PR DESCRIPTION
## Changelog Description
Change selection to first index in workfiles view after refresh.

## Additional info
This does now affect only workarea widget, and does not handle actual index data value, only uses first row (can be different index if sorted by names). Probably should be implemented for published workfiles too?

## Testing notes:
1. When context selection changes, first workfile in view is selected.
