### PR TITLE
Houdini: Add 'Make AYON Publishable' to OPMenu

### DIFF
--- a/client/ayon_core/hosts/houdini/startup/OPmenu.xml
+++ b/client/ayon_core/hosts/houdini/startup/OPmenu.xml
@@ -5,6 +5,24 @@
 
 <menuDocument>
     <menu>
+
+        <scriptItem id="opmenu.generic_create_ayon">
+            <label>Make AYON Publishable</label>
+            <context>
+                <expression>hasattr(kwargs["node"], "render")</expression>
+            </context>
+            <scriptCode>
+<![CDATA[
+from ayon_core.hosts.houdini.api.creator_node_shelves import create_interactive
+
+node = kwargs["node"]
+node.setSelected(True)
+create_interactive("io.ayon.creators.houdini.publish", **kwargs)
+]]>
+             </scriptCode>
+        </scriptItem>
+        <separatorItem/>
+
         <!-- Operator type and asset options. -->
         <subMenu id="opmenu.vhda_options_create">
             <insertBefore>opmenu.unsynchronize</insertBefore>


### PR DESCRIPTION
## Changelog Description
Add `Make AYON Publishable` to OPMenu



## Testing notes:
1. Launch Houdini via AYON Launcher
2. Create any rop node, right-click  and select `Make AYON Publishable`, it should have the same behavior when selecting generic creator in the creator tool.
