### PR TITLE
Houdini: add 'generic' family to collect farm instances and skip render if local publishing.

### DIFF
--- a/client/ayon_core/hosts/houdini/plugins/publish/collect_farm_instances.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/collect_farm_instances.py
@@ -9,7 +9,8 @@ class CollectFarmInstances(pyblish.api.InstancePlugin):
                 "karma_rop",
                 "redshift_rop",
                 "arnold_rop",
-                "vray_rop"]
+                "vray_rop",
+                "generic"]
 
     hosts = ["houdini"]
     targets = ["local", "remote"]

--- a/client/ayon_core/hosts/houdini/plugins/publish/extract_rop.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/extract_rop.py
@@ -37,8 +37,10 @@ class ExtractROP(publish.Extractor):
         }
 
         # render rop
-        ropnode = hou.node(instance.data.get("instance_node"))
-        lib.render_rop(ropnode)
+        creator_attribute = instance.data["creator_attributes"]
+        if creator_attribute.get("render_target") == "local":
+            ropnode = hou.node(instance.data.get("instance_node"))
+            lib.render_rop(ropnode)
 
         # add representation
         instance.data.setdefault("representations", []).append(representation)


### PR DESCRIPTION
## Changelog Description
add 'generic' family to collect farm instances and skip render if local publishing.

## Testing notes:
1. Launch Houdini via AYON Launcher
2. Create a generic instance. set render target to `Use existing frames (local)` and publish. It shouldn't render the node.
3. Create a generic instance. set render target to `Local machine rendering` and publish. It should render the node.
