### PR TITLE
Support render targets for 'usdrender' product type

### DIFF
--- a/client/ayon_core/modules/deadline/plugins/publish/submit_houdini_render_deadline.py
+++ b/client/ayon_core/modules/deadline/plugins/publish/submit_houdini_render_deadline.py
@@ -71,6 +71,7 @@ class HuskStandalonePluginInfo():
     PostFrame = attr.ib(default="")
     PostRender = attr.ib(default="")
     RestartDelegate = attr.ib(default="")
+    Version = attr.ib(default="")
 
 
 class HoudiniSubmitDeadline(
@@ -289,7 +290,7 @@ class HoudiniSubmitDeadline(
         instance = self._instance
         context = instance.context
 
-        hou_major_minor = hou.applicationVersionString().rsplit(".", 1)[0]
+        self.hou_major_minor = hou.applicationVersionString().rsplit(".", 1)[0]
 
         # Output driver to render
         if job_type == "render":
@@ -301,7 +302,7 @@ class HoudiniSubmitDeadline(
             elif product_type == "mantra_rop":
                 plugin_info = MantraRenderDeadlinePluginInfo(
                     SceneFile=instance.data["ifdFile"],
-                    Version=hou_major_minor,
+                    Version=self.hou_major_minor,
                 )
             elif product_type == "vray_rop":
                 plugin_info = VrayRenderPluginInfo(
@@ -340,7 +341,7 @@ class HoudiniSubmitDeadline(
             plugin_info = DeadlinePluginInfo(
                 SceneFile=context.data["currentFile"],
                 OutputDriver=driver.path(),
-                Version=hou_major_minor,
+                Version=self.hou_major_minor,
                 IgnoreInputs=True
             )
 
@@ -389,7 +390,8 @@ class HoudiniSubmitDeadline(
             PreFrame=rop_node.evalParm("husk_preframe"),
             PostFrame=rop_node.evalParm("husk_postframe"),
             PostRender=rop_node.evalParm("husk_postrender"),
-            RestartDelegate=restart_delegate
+            RestartDelegate=restart_delegate,
+            Version=self.hou_major_minor
         )
 
 

--- a/client/ayon_core/modules/deadline/plugins/publish/submit_houdini_render_deadline.py
+++ b/client/ayon_core/modules/deadline/plugins/publish/submit_houdini_render_deadline.py
@@ -97,7 +97,9 @@ class HoudiniSubmitDeadline(
                 "arnold_rop",
                 "mantra_rop",
                 "karma_rop",
-                "vray_rop"]
+                "vray_rop",
+                "usdrender"]
+
     targets = ["local"]
     use_published = True
 

--- a/server_addon/houdini/client/ayon_houdini/plugins/publish/collect_farm_instances.py
+++ b/server_addon/houdini/client/ayon_houdini/plugins/publish/collect_farm_instances.py
@@ -10,7 +10,8 @@ class CollectFarmInstances(plugin.HoudiniInstancePlugin):
                 "karma_rop",
                 "redshift_rop",
                 "arnold_rop",
-                "vray_rop"]
+                "vray_rop",
+                "usdrender"]
 
     targets = ["local", "remote"]
     label = "Collect farm instances"

--- a/server_addon/houdini/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
+++ b/server_addon/houdini/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
@@ -21,7 +21,8 @@ class CollectLocalRenderInstances(plugin.HoudiniInstancePlugin):
                 "karma_rop",
                 "redshift_rop",
                 "arnold_rop",
-                "vray_rop"]
+                "vray_rop",
+                "usdrender"]
 
     label = "Collect local render instances"
 

--- a/server_addon/houdini/client/ayon_houdini/plugins/publish/collect_render_products.py
+++ b/server_addon/houdini/client/ayon_houdini/plugins/publish/collect_render_products.py
@@ -25,7 +25,7 @@ class CollectRenderProducts(plugin.HoudiniInstancePlugin):
     """
 
     label = "Collect Render Products"
-    order = pyblish.api.CollectorOrder + 0.4
+    order = pyblish.api.CollectorOrder + 0.04
     families = ["usdrender"]
 
     def process(self, instance):
@@ -44,6 +44,7 @@ class CollectRenderProducts(plugin.HoudiniInstancePlugin):
 
         filenames = []
         files_by_product = {}
+
         stage = node.stage()
         for prim_path in self.get_render_products(rop_node, stage):
             prim = stage.GetPrimAtPath(prim_path)
@@ -131,12 +132,16 @@ class CollectRenderProducts(plugin.HoudiniInstancePlugin):
             self.log.debug("Render Product %s%s", aov_label, prim_path)
             self.log.debug("Product name: %s", filename)
 
+
+        # As long as we have one AOV then multipartExr should be True.
+        instance.data["multipartExr"] = len(files_by_product) <= 1
+
         # Filenames for Deadline
         instance.data["files"] = filenames
         instance.data.setdefault("expectedFiles", []).append(files_by_product)
 
     def get_aov_identifier(self, render_product):
-        """Return the AOV identfier for a Render Product
+        """Return the AOV identifier for a Render Product
 
         A Render Product does not really define what 'AOV' it is, it
         defines the product name (output path) and the render vars to

--- a/server_addon/houdini/client/ayon_houdini/plugins/publish/collect_reviewable_instances.py
+++ b/server_addon/houdini/client/ayon_houdini/plugins/publish/collect_reviewable_instances.py
@@ -15,7 +15,8 @@ class CollectReviewableInstances(plugin.HoudiniInstancePlugin):
                 "karma_rop",
                 "redshift_rop",
                 "arnold_rop",
-                "vray_rop"]
+                "vray_rop",
+                "usdrender"]
 
     def process(self, instance):
         creator_attribute = instance.data["creator_attributes"]

--- a/server_addon/houdini/client/ayon_houdini/plugins/publish/collect_usd_render.py
+++ b/server_addon/houdini/client/ayon_houdini/plugins/publish/collect_usd_render.py
@@ -35,10 +35,7 @@ class CollectUsdRender(pyblish.api.InstancePlugin):
 
         rop = hou.node(instance.data.get("instance_node"))
 
-        # Store whether we are splitting the render job in an export + render
-        split_render = not rop.parm("runcommand").eval()
-        instance.data["splitRender"] = split_render
-        if split_render:
+        if instance.data["splitRender"]:
             # USD file output
             lop_output = evalParmNoFrame(
                 rop, "lopoutput", pad_character="#"
@@ -75,7 +72,7 @@ class CollectUsdRender(pyblish.api.InstancePlugin):
             if "$F" not in export_file:
                 instance.data["splitRenderFrameDependent"] = False
 
-        instance.data["farm"] = True  # always submit to farm
+        # instance.data["farm"] = True  # always submit to farm
 
         # update the colorspace data
         colorspace_data = get_color_management_preferences()

--- a/server_addon/houdini/client/ayon_houdini/plugins/publish/extract_render.py
+++ b/server_addon/houdini/client/ayon_houdini/plugins/publish/extract_render.py
@@ -15,7 +15,8 @@ class ExtractRender(plugin.HoudiniExtractorPlugin):
                 "karma_rop",
                 "redshift_rop",
                 "arnold_rop",
-                "vray_rop"]
+                "vray_rop",
+                "usdrender"]
 
     def process(self, instance):
         creator_attribute = instance.data["creator_attributes"]
@@ -32,6 +33,8 @@ class ExtractRender(plugin.HoudiniExtractorPlugin):
                 rop_node.setParms({"RS_archive_enable": 1})
             elif product_type == "vray_rop":
                 rop_node.setParms({"render_export_mode": "2"})
+            elif product_type == "usdrender":
+                rop_node.setParms({"runcommand": 0})
         else:
             if product_type == "arnold_rop":
                 rop_node.setParms({"ar_ass_export_enable": 0})
@@ -41,6 +44,8 @@ class ExtractRender(plugin.HoudiniExtractorPlugin):
                 rop_node.setParms({"RS_archive_enable": 0})
             elif product_type == "vray_rop":
                 rop_node.setParms({"render_export_mode": "1"})
+            elif product_type == "usdrender":
+                rop_node.setParms({"runcommand": 1})
 
         if instance.data.get("farm"):
             self.log.debug("Render should be processed on farm, skipping local render.")

--- a/server_addon/houdini/client/ayon_houdini/plugins/publish/validate_usd_render_arnold.py
+++ b/server_addon/houdini/client/ayon_houdini/plugins/publish/validate_usd_render_arnold.py
@@ -35,7 +35,7 @@ class ValidateUSDRenderSingleFile(pyblish.api.InstancePlugin):
         )
         render_chunk_size = submission_data.get("chunk", 1)
         export_chunk_size = submission_data.get("export_chunk", 1)
-        usd_file_per_frame = "$F" in instance.data["ifdFile"]
+        usd_file_per_frame = instance.data["farm"]
         frame_start_handle = instance.data["frameStartHandle"]
         frame_end_handle = instance.data["frameEndHandle"]
         num_frames = frame_end_handle - frame_start_handle + 1

--- a/server_addon/houdini/client/ayon_houdini/plugins/publish/validate_usd_render_product_paths.py
+++ b/server_addon/houdini/client/ayon_houdini/plugins/publish/validate_usd_render_product_paths.py
@@ -26,6 +26,7 @@ class ValidateUSDRenderProductPaths(pyblish.api.InstancePlugin):
     hosts = ["houdini"]
     label = "Validate USD Render Product Paths"
     optional = True
+    enabled = False
 
     def process(self, instance):
 


### PR DESCRIPTION
## Changelog Description
Support render targets for 'usdrender' product type
This also includes
- Submitted to Deadline Husk Standalone renders (with split export jobs)
- Mark render as reviewable. 

## Additional info
It works fine on my side. 
But, for some reason I don't know yet, the jobs are submitted twice ?! 
![image](https://github.com/BigRoy/ayon-core/assets/20871534/027347a3-b5f5-4523-a2b0-44f221857a6e)


## Testing notes:
1. Publish `usdrender` from Houdini using the four options:
  - Local machine rendering
  - Use existing frames (local)
  - Farm Rendering
  - Farm Rendering - Split export & render jobs
2. Also test `Review` _mark as reviewable._